### PR TITLE
chore: remove deprecated authors field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ license = "GPL-3.0-only"
 repository = "https://github.com/GideonBear/falconf"
 keywords = ["configuration", "synchronization"]
 categories = ["command-line-utilities"]
-authors = ["GideonBear"]
 version = "0.2.21"
 edition = "2024"
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos