### PR TITLE
Revert "chore(deps): pin dtolnay/rust-toolchain action to 29eef33"

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - &install-rust
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5


### PR DESCRIPTION
Reverts GideonBear/falconf#101
Bogus, idk why Renovate suggested this. `gha-pin` will fix this later.